### PR TITLE
Add color scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/xcode,swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=xcode,swift
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/xcode,swift

--- a/Wonky Blocks.xcodeproj/project.pbxproj
+++ b/Wonky Blocks.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0088A4002527453200A1035F /* ColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0088A3FF2527453200A1035F /* ColorTheme.swift */; };
+		0088A40425274A0D00A1035F /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0088A40325274A0D00A1035F /* UIColor+Hex.swift */; };
 		453EDD6224998982006470E7 /* Joystick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453EDD6124998982006470E7 /* Joystick.swift */; };
 		453FBC7D249AE0310056E4D7 /* SwiftClipper in Frameworks */ = {isa = PBXBuildFile; productRef = 453FBC7C249AE0310056E4D7 /* SwiftClipper */; };
 		45525A69244C7FD4004974AB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45525A68244C7FD4004974AB /* AppDelegate.swift */; };
@@ -35,6 +37,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0088A3FF2527453200A1035F /* ColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTheme.swift; sourceTree = "<group>"; };
+		0088A40325274A0D00A1035F /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
 		45332F4C24ECA5D900F7A72C /* preview.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = preview.gif; sourceTree = "<group>"; };
 		453EDD6124998982006470E7 /* Joystick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joystick.swift; sourceTree = "<group>"; };
 		45525A65244C7FD4004974AB /* Wonky Blocks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wonky Blocks.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -78,6 +82,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0088A40625275EA000A1035F /* color */ = {
+			isa = PBXGroup;
+			children = (
+				0088A3FF2527453200A1035F /* ColorTheme.swift */,
+				0088A40325274A0D00A1035F /* UIColor+Hex.swift */,
+			);
+			path = color;
+			sourceTree = "<group>";
+		};
 		451B41B3246766FE007D559A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -139,6 +152,7 @@
 		45A248A92496580D0030EC50 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				0088A40625275EA000A1035F /* color */,
 				45BEC135244E5D6400B38F83 /* SwiftClipperPath+asCgPath.swift */,
 				45A248A1249656E10030EC50 /* GamePhysicsController.swift */,
 				45A248A3249657210030EC50 /* GamePhysicsController+keyboardControls.swift */,
@@ -256,6 +270,7 @@
 			files = (
 				453EDD6224998982006470E7 /* Joystick.swift in Sources */,
 				45A248A2249656E10030EC50 /* GamePhysicsController.swift in Sources */,
+				0088A40425274A0D00A1035F /* UIColor+Hex.swift in Sources */,
 				45525A69244C7FD4004974AB /* AppDelegate.swift in Sources */,
 				45A248C124965B3C0030EC50 /* WonkyRow.swift in Sources */,
 				45A248AC2496586C0030EC50 /* RootView.swift in Sources */,
@@ -273,6 +288,7 @@
 				45A248B4249659180030EC50 /* GameState.swift in Sources */,
 				45A248B0249658B60030EC50 /* ScoreBoardView.swift in Sources */,
 				45A248B9249659D90030EC50 /* WonkyRowIndicator.swift in Sources */,
+				0088A4002527453200A1035F /* ColorTheme.swift in Sources */,
 				45A248BD24965AF30030EC50 /* GameViewController.swift in Sources */,
 				45A248C524965BB40030EC50 /* physicsCategories.swift in Sources */,
 			);

--- a/Wonky Blocks/Support/color/ColorTheme.swift
+++ b/Wonky Blocks/Support/color/ColorTheme.swift
@@ -1,0 +1,46 @@
+//
+//  ColorTheme.swift
+//  Wonky Blocks
+//
+//  Created by Ashley Si on 2/10/20.
+//  Copyright © 2020 Benjamin Kindle. All rights reserved.
+//
+
+import UIKit
+
+// TODO: add menu to change color theme
+var currentTheme: ColorTheme = .rainbow
+
+enum ColorTheme {
+    case rainbow, pastel, goodOldBlue
+    
+    var randomColor: UIColor {
+        return self.colorPalette.randomElement()!
+    }
+    
+    var colorPalette: [UIColor] {
+        switch self {
+        case .rainbow:
+            return [
+              .red,
+              .orange,
+              .yellow,
+              .green,
+              .blue,
+              .cyan,
+              .purple,
+            ]
+        case .pastel:
+            return [
+              UIColor(hex: 0xffd5e5),
+              UIColor(hex: 0xffffdd),
+              UIColor(hex: 0xa0ffe6),
+              UIColor(hex: 0x81f5ff),
+              UIColor(hex: 0xc295d8),
+              UIColor(hex: 0xffd3b6),
+            ]
+        case .goodOldBlue:
+            return [.blue]
+        }
+    }
+}

--- a/Wonky Blocks/Support/color/UIColor+Hex.swift
+++ b/Wonky Blocks/Support/color/UIColor+Hex.swift
@@ -1,0 +1,18 @@
+//
+//  UIColor+Hex.swift
+//  Wonky Blocks
+//
+//  Created by Ashley Si on 2/10/20.
+//  Copyright © 2020 Benjamin Kindle. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    convenience init(hex: UInt32, alpha: CGFloat = 1.0) {
+        let red = CGFloat((hex & 0xFF0000) >> 16) / 255.0
+        let green = CGFloat((hex & 0xFF00) >> 8) / 255.0
+        let blue = CGFloat(hex & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/Wonky Blocks/UI/SKNodes/WonkyTetronimo.swift
+++ b/Wonky Blocks/UI/SKNodes/WonkyTetronimo.swift
@@ -19,13 +19,9 @@ class WonkyTetronimo: SKShapeNode {
         return center
     }
 
-    override init() {
-        super.init()
-    }
-
     /// initialize using a grid of rows and columns indicating whether each position should include a block or be empty
-    convenience init(grid: [[Bool]]) {
-        self.init()
+    init(grid: [[Bool]], color: UIColor = currentTheme.randomColor) {
+        super.init()
         var physicsBodies: [SKPhysicsBody] = []
         for col in grid.enumerated() {
             for row in col.element.enumerated() {
@@ -37,7 +33,7 @@ class WonkyTetronimo: SKShapeNode {
                     square.userData = NSMutableDictionary()
                     square.userData?.setValue(path.getPathElementsPoints().asClockwise().centroid, forKey: "center")
                     square.lineWidth = 1
-                    square.fillColor = .blue
+                    square.fillColor = color
                     square.strokeColor = .clear
                     let physicsBody = SKPhysicsBody(polygonFrom: path)
 
@@ -47,13 +43,13 @@ class WonkyTetronimo: SKShapeNode {
             }
         }
         self.physicsBody = SKPhysicsBody(bodies: physicsBodies)
-        self.setup()
+        self.setup(color: color)
     }
 
     /// creates a tetronimo from a collection of paths. Used to create a tetronimo that replaces a piece that's been chopped up by a removed line.
     /// the orignal center point of each path is also saved into the userData of the nodes
-    convenience init(with childrenPaths: [(path: Path, center: CGPoint)]) {
-        self.init()
+    init(with childrenPaths: [(path: Path, center: CGPoint)], color: UIColor = currentTheme.randomColor) {
+        super.init()
         let children = childrenPaths.compactMap{(path) -> (SKPhysicsBody, SKShapeNode)? in
             guard let physicsBody = SKPhysicsBody(polygonFrom: path.path.asCgPath()) as SKPhysicsBody?  else {
                 // sometimes physics bodies fail to create from paths - we don't seem to miss any important nodes because of this.
@@ -62,7 +58,7 @@ class WonkyTetronimo: SKShapeNode {
             let diffNode = SKShapeNode(path: path.path.asCgPath())
             diffNode.userData = NSMutableDictionary()
             diffNode.userData?.setValue(path.path.asClockwise().centroid, forKey: "center")
-            diffNode.fillColor = .blue
+            diffNode.fillColor = color
             diffNode.lineWidth = 1
             diffNode.strokeColor = .clear
             return (physicsBody, diffNode)
@@ -71,10 +67,10 @@ class WonkyTetronimo: SKShapeNode {
             self.addChild(node)
         }
         self.physicsBody = SKPhysicsBody(bodies: children.map{$0.0})
-        self.setup()
+        self.setup(color: color)
     }
 
-    private func setup() {
+    private func setup(color: UIColor) {
         physicsBody?.affectedByGravity = false
         physicsBody?.categoryBitMask = tetCategory
         physicsBody?.contactTestBitMask = tetCategory | rowCategory
@@ -85,7 +81,7 @@ class WonkyTetronimo: SKShapeNode {
         physicsBody?.restitution = 0.05
 
         name = "tet"
-        fillColor = .blue
+        fillColor = color
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
fixes issue #8 

## What's new
- added gitignore for easier collaboration
- some clean up on the init method of WonkyTetronimo
- init color from hex
- color scheme palette and a global var for the current theme
- a random color in the theme is picked each time a c is created

## After
| Rainbow | Pastel |
|-------|------|
|![Simulator Screen Shot - iPhone 11 Pro - 2020-10-02 at 21 51 21](https://user-images.githubusercontent.com/13992714/94930882-a2d26f80-04f9-11eb-8ee0-ea942113de68.png)|![Simulator Screen Shot - iPhone 11 Pro - 2020-10-02 at 19 55 43](https://user-images.githubusercontent.com/13992714/94930912-acf46e00-04f9-11eb-881f-30985f7ec3b8.png)|

## Next steps
- add a menu item to change the color theme
- right now, when some row gets cleared, new WonkyTetronimos are created and can be different colors. it might be better if we can preserve the original colors
- additional points when the same colored blocks contact and clear?

